### PR TITLE
Update traefik healthchecks to be quieter

### DIFF
--- a/setup-compose.yml
+++ b/setup-compose.yml
@@ -65,7 +65,7 @@ services:
       - --metrics.prometheus.entryPoint=metrics
       - --serverstransport.insecureskipverify=true
     healthcheck:
-      test: ["CMD", "wget", "-c", "http://localhost:8081/ping"]
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "-c", "http://localhost:8081/ping"]
       interval: 1s
       timeout: 1s
       retries: 10

--- a/setup-swarm.yml
+++ b/setup-swarm.yml
@@ -71,7 +71,7 @@ services:
       - --metrics.prometheus.entryPoint=metrics
       - --serverstransport.insecureskipverify=true
     healthcheck:
-      test: ["CMD", "wget", "-c", "http://localhost:8081/ping"]
+      test: ["CMD", "wget", "-q", "-O", "/dev/null", "-c", "http://localhost:8081/ping"]
       interval: 1s
       timeout: 1s
       retries: 10


### PR DESCRIPTION
There's no reason to have `wget` "save" the ping output, nor see the progress bar in the `docker inspect` output.

Yes I am an unapologetic pedant.