### PR TITLE
Fix indentation in setup-compose.yml

### DIFF
--- a/setup-compose.yml
+++ b/setup-compose.yml
@@ -18,7 +18,7 @@ services:
       - 80:80
       - 443:443
     deploy:
-    resources:
+      resources:
         reservations:
           cpus: '0.01'
           memory: 50M


### PR DESCRIPTION
As per `docker-compose.yml` spec, the `resources` setting is a child of `deploy`. Intentation was wrong here preventing the system to run and resulting in an error: `services.traefik Additional property resources is not allowed`.